### PR TITLE
Added option to open files as non-previews

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ const Utils = {
       if ( isTextDocument ) {
 
         return vscode.workspace.openTextDocument ( fileuri )
-                                .then ( vscode.window.showTextDocument );
+                                .then (doc => vscode.window.showTextDocument(doc, {preview: false}) );
 
       } else {
 


### PR DESCRIPTION
If VSCode settings are set to open files as previews by default, the extension would open them all as such, and so close all but the last. That's probably not what the user wants, so here's a small fix.